### PR TITLE
Minor refactor for mingw, data type tweaks, and warning removal.

### DIFF
--- a/DarkLoadLibrary/include/darkloadlibrary.h
+++ b/DarkLoadLibrary/include/darkloadlibrary.h
@@ -1,21 +1,24 @@
+#pragma once
 #include <stdio.h>
 #include <windows.h>
+#include "darkmodule.h"
+#include "pebutils.h"
+#include "ldrutils.h"
 
 #define LOAD_LOCAL_FILE  0x00000001
 #define LOAD_REMOTE_FILE 0x00000002
 #define LOAD_MEMORY		 0x00000003
 #define NO_LINK			 0x00000004
 
-#pragma once
-typedef struct _DARKMODULE {
-    BOOL      bSuccess;
-	LPWSTR	  ErrorMsg;
-	PBYTE	  pbDllData;
-	DWORD	  dwDllDataLen;
-	LPWSTR    LocalDLLName;
-	PWCHAR 	  CrackedDLLName;
-    ULONG_PTR ModuleBase;
-} DARKMODULE, *PDARKMODULE;
+// typedef struct _DARKMODULE {
+//     BOOL      bSuccess;
+// 	LPWSTR	  ErrorMsg;
+// 	PBYTE	  pbDllData;
+// 	DWORD	  dwDllDataLen;
+// 	LPWSTR    LocalDLLName;
+// 	PWCHAR 	  CrackedDLLName;
+//     ULONG_PTR ModuleBase;
+// } DARKMODULE, *PDARKMODULE;
 
 DARKMODULE DarkLoadLibrary(
 	DWORD   dwFlags,
@@ -23,4 +26,18 @@ DARKMODULE DarkLoadLibrary(
 	LPVOID	lpFileBuffer,
 	DWORD   dwLen,
 	LPCWSTR lpwName
+);
+
+BOOL ParseFileName(
+	PDARKMODULE pdModule,
+	LPWSTR lpwFileName
+);
+
+BOOL ReadFileToBuffer(
+	PDARKMODULE pdModule
+);
+
+BOOL ConcealLibrary(
+	PDARKMODULE pdModule,
+	BOOL bConceal
 );

--- a/DarkLoadLibrary/include/darkmodule.h
+++ b/DarkLoadLibrary/include/darkmodule.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <windows.h>
+
+typedef struct _DARKMODULE {
+    BOOL      bSuccess;
+	LPWSTR	  ErrorMsg;
+	PBYTE	  pbDllData;
+	DWORD	  dwDllDataLen;
+	LPWSTR    LocalDLLName;
+	PWCHAR 	  CrackedDLLName;
+    ULONG_PTR ModuleBase;
+} DARKMODULE, *PDARKMODULE;

--- a/DarkLoadLibrary/include/ldrutils.h
+++ b/DarkLoadLibrary/include/ldrutils.h
@@ -1,7 +1,7 @@
+#pragma once
 #include <windows.h>
-
 #include "pebutils.h"
-#include "darkloadlibrary.h"
+#include "darkmodule.h"
 
 #define RVA(type, base_addr, rva) (type)((ULONG_PTR) base_addr + rva)
 
@@ -15,3 +15,5 @@ typedef NTSTATUS(WINAPI *LDRGETPROCADDRESS)(HMODULE, PANSI_STRING, WORD, PVOID*)
 
 BOOL IsValidPE(PBYTE pbData);
 BOOL MapSections(PDARKMODULE pdModule);
+BOOL ResolveImports(PDARKMODULE pdModule);
+BOOL BeginExecution(PDARKMODULE pdModule);

--- a/DarkLoadLibrary/include/pebutils.h
+++ b/DarkLoadLibrary/include/pebutils.h
@@ -1,5 +1,5 @@
 #include <windows.h>
-
+#include <stddef.h>
 #include "pebstructs.h"
 #include "darkloadlibrary.h"
 

--- a/DarkLoadLibrary/include/pebutils.h
+++ b/DarkLoadLibrary/include/pebutils.h
@@ -1,6 +1,8 @@
+#pragma once
 #include <windows.h>
 #include <stddef.h>
 #include "pebstructs.h"
+#include "darkmodule.h"
 #include "darkloadlibrary.h"
 
 #ifdef _WIN32
@@ -26,3 +28,34 @@
 
 HMODULE IsModulePresent(LPCWSTR lpwName);
 BOOL LinkModuleToPEB(PDARKMODULE pdModule);
+ULONG LdrHashEntry(UNICODE_STRING UniName, BOOL XorHash);
+PLDR_DATA_TABLE_ENTRY2 FindLdrTableEntry(
+	PCWSTR BaseName
+);
+PRTL_RB_TREE FindModuleBaseAddressIndex();
+BOOL AddBaseAddressEntry(
+	PLDR_DATA_TABLE_ENTRY2 pLdrEntry,
+	PVOID lpBaseAddr
+);
+PLIST_ENTRY FindHashTable();
+VOID InsertTailList(
+	PLIST_ENTRY ListHead,
+	PLIST_ENTRY Entry
+);
+BOOL AddHashTableEntry(
+	PLDR_DATA_TABLE_ENTRY2 pLdrEntry
+);
+
+NTSTATUS RtlHashUnicodeString(
+  PCUNICODE_STRING String,
+  BOOLEAN          CaseInSensitive,
+  ULONG            HashAlgorithm,
+  PULONG           HashValue
+);
+
+void RtlRbInsertNodeEx(
+    RTL_RB_TREE *Tree, 
+    RTL_BALANCED_NODE *Parent, 
+    BOOLEAN Right, 
+    RTL_BALANCED_NODE *Node
+);

--- a/DarkLoadLibrary/src/darkloadlibrary.c
+++ b/DarkLoadLibrary/src/darkloadlibrary.c
@@ -58,12 +58,12 @@ BOOL ParseFileName(
 		return FALSE;
 	}
 
-	PCHAR lpCpy = wcscpy(
+	PWCHAR lpCpy = wcscpy(
 		pdModule->CrackedDLLName,
 		lpwFilename
 	);
     
-	PCHAR lpCat = wcscat(
+	PWCHAR lpCat = wcscat(
 		pdModule->CrackedDLLName,
 		lpwExt
 	);

--- a/DarkLoadLibrary/src/pebutils.c
+++ b/DarkLoadLibrary/src/pebutils.c
@@ -58,7 +58,7 @@ PLDR_DATA_TABLE_ENTRY2 FindLdrTableEntry(
 
 PRTL_RB_TREE FindModuleBaseAddressIndex()
 {
-	SIZE_T stEnd = NULL;
+	SIZE_T stEnd = 0;
 	PRTL_BALANCED_NODE pNode = NULL;
 	PRTL_RB_TREE pModBaseAddrIndex = NULL;
 
@@ -73,8 +73,8 @@ PRTL_RB_TREE FindModuleBaseAddressIndex()
 
 	if (!pNode->Red)
 	{
-		DWORD dwLen = NULL;
-		SIZE_T stBegin = NULL;
+		DWORD dwLen = 0;
+		SIZE_T stBegin = 0;
 
 		PIMAGE_NT_HEADERS pNtHeaders = RVA(
 			PIMAGE_NT_HEADERS, 

--- a/DarkLoadLibrary/src/pebutils.c
+++ b/DarkLoadLibrary/src/pebutils.c
@@ -73,8 +73,8 @@ PRTL_RB_TREE FindModuleBaseAddressIndex()
 
 	if (!pNode->Red)
 	{
-		DWORD dwLen = 0;
-		SIZE_T stBegin = 0;
+		DWORD dwLen = NULL;
+		SIZE_T stBegin = NULL;
 
 		PIMAGE_NT_HEADERS pNtHeaders = RVA(
 			PIMAGE_NT_HEADERS, 

--- a/DarkLoadLibrary/src/pebutils.c
+++ b/DarkLoadLibrary/src/pebutils.c
@@ -58,7 +58,7 @@ PLDR_DATA_TABLE_ENTRY2 FindLdrTableEntry(
 
 PRTL_RB_TREE FindModuleBaseAddressIndex()
 {
-	SIZE_T stEnd = 0;
+	SIZE_T stEnd = NULL;
 	PRTL_BALANCED_NODE pNode = NULL;
 	PRTL_RB_TREE pModBaseAddrIndex = NULL;
 


### PR DESCRIPTION
I made a few minor tweaks to better support mingw and to reduce compiler warnings:

*  Added function signatures to corresponding header files to remove `no previous declaration for` warnings.
* A new header `darkmodule.h` was created to contain the `_DARKMODULE` struct definition. This is so that `darkloadlibrary.h` can include each of the other headers with their new function signatures.
* A couple variables were `PCHAR`s instead of `PWCHAR`s.