### PR TITLE
Find DLL exports

### DIFF
--- a/DarkLoadLibrary/DarkLoadLibrary.vcxproj.filters
+++ b/DarkLoadLibrary/DarkLoadLibrary.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">

--- a/DarkLoadLibrary/include/darkloadlibrary.h
+++ b/DarkLoadLibrary/include/darkloadlibrary.h
@@ -13,11 +13,11 @@ typedef struct _DARKMODULE {
 	PBYTE	  pbDllData;
 	DWORD	  dwDllDataLen;
 	LPWSTR    LocalDLLName;
-	PWCHAR 	  CrackedDLLName;
+	PWCHAR CrackedDLLName;
     ULONG_PTR ModuleBase;
 } DARKMODULE, *PDARKMODULE;
 
-DARKMODULE DarkLoadLibrary(
+PDARKMODULE DarkLoadLibrary(
 	DWORD   dwFlags,
 	LPCWSTR lpwBuffer,
 	LPVOID	lpFileBuffer,

--- a/DarkLoadLibrary/include/ldrutils.h
+++ b/DarkLoadLibrary/include/ldrutils.h
@@ -10,3 +10,7 @@ typedef NTSTATUS(WINAPI *LDRGETPROCADDRESS)(HMODULE, PANSI_STRING, WORD, PVOID*)
 
 BOOL IsValidPE(PBYTE pbData);
 BOOL MapSections(PDARKMODULE pdModule);
+BOOL ResolveImports(PDARKMODULE pdModule);
+BOOL LinkModuleToPEB(PDARKMODULE pdModule);
+BOOL BeginExecution(PDARKMODULE pdModule);
+wchar_t* FindDLLPath(wchar_t* path, wchar_t* libname_w);

--- a/DarkLoadLibrary/include/ldrutils.h
+++ b/DarkLoadLibrary/include/ldrutils.h
@@ -13,4 +13,3 @@ BOOL MapSections(PDARKMODULE pdModule);
 BOOL ResolveImports(PDARKMODULE pdModule);
 BOOL LinkModuleToPEB(PDARKMODULE pdModule);
 BOOL BeginExecution(PDARKMODULE pdModule);
-wchar_t* FindDLLPath(wchar_t* path, wchar_t* libname_w);

--- a/DarkLoadLibrary/include/ldrutils.h
+++ b/DarkLoadLibrary/include/ldrutils.h
@@ -5,11 +5,6 @@
 
 #define RVA(type, base_addr, rva) (type)((ULONG_PTR) base_addr + rva)
 
-#define FILL_STRING(string, buffer) \
-	string.Length = (USHORT)strlen(buffer); \
-	string.MaximumLength = string.Length; \
-	string.Buffer = buffer
-
 typedef BOOL(WINAPI * DLLMAIN)(HINSTANCE, DWORD, LPVOID);
 typedef NTSTATUS(WINAPI *LDRGETPROCADDRESS)(HMODULE, PANSI_STRING, WORD, PVOID*);
 

--- a/DarkLoadLibrary/include/ldrutils.h
+++ b/DarkLoadLibrary/include/ldrutils.h
@@ -6,7 +6,7 @@
 #define RVA(type, base_addr, rva) (type)((ULONG_PTR) base_addr + rva)
 
 typedef BOOL(WINAPI * DLLMAIN)(HINSTANCE, DWORD, LPVOID);
-typedef NTSTATUS(WINAPI *LDRGETPROCADDRESS)(HMODULE, PANSI_STRING, WORD, PVOID*);
+typedef HMODULE(WINAPI* LOADLIBRARYA)(LPCSTR);
 
 BOOL IsValidPE(PBYTE pbData);
 BOOL MapSections(PDARKMODULE pdModule);

--- a/DarkLoadLibrary/include/pebutils.h
+++ b/DarkLoadLibrary/include/pebutils.h
@@ -8,12 +8,15 @@
     string.MaximumLength = string.Length; \
     string.Buffer = buffer
 
+typedef NTSTATUS(WINAPI* LDRGETPROCADDRESS)(HMODULE, PANSI_STRING, WORD, PVOID*);
+typedef VOID(WINAPI* RTLRBINSERTNODEEX)(_In_ PRTL_RB_TREE Tree, _In_opt_ PRTL_BALANCED_NODE Parent, _In_ BOOLEAN Right, _Out_ PRTL_BALANCED_NODE Node);
+
 #ifdef _WIN64
     #define PEB_OFFSET 0x60
     #define READ_MEMLOC __readgsqword 
 #else
 #define PEB_OFFSET 0x30
-#define READ_MEMLOC __readfsdword
+#define READ_MEMLOC __readfsdword 
 #endif
 
 #pragma once
@@ -27,8 +30,12 @@
 
 #define LDR_HASH_TABLE_ENTRIES 32
 
+NTSYSAPI NTSTATUS NTAPI RtlHashUnicodeString(__in PCUNICODE_STRING String, __in BOOLEAN CaseInSensitive, __in ULONG HashAlgorithm, __out PULONG HashValue);
+NTSYSAPI VOID NTAPI RtlRbInsertNodeEx(_In_ PRTL_RB_TREE Tree, _In_opt_ PRTL_BALANCED_NODE Parent, _In_ BOOLEAN Right, _Out_ PRTL_BALANCED_NODE Node);
+
 HMODULE IsModulePresent(LPCWSTR lpwName);
 HMODULE IsModulePresentA(char* Name);
 BOOL LinkModuleToPEB(PDARKMODULE pdModule);
 FARPROC GetFunctionAddress(HMODULE hModule, char*  ProcName);
 BOOL LocalLdrGetProcedureAddress(HMODULE hLibrary, PANSI_STRING ProcName, WORD Ordinal, PVOID* FunctionAddress);
+BOOL _LocalLdrGetProcedureAddress(HMODULE hLibrary, PANSI_STRING ProcName, WORD Ordinal, PVOID* FunctionAddress);

--- a/DarkLoadLibrary/include/pebutils.h
+++ b/DarkLoadLibrary/include/pebutils.h
@@ -8,14 +8,12 @@
     string.MaximumLength = string.Length; \
     string.Buffer = buffer
 
-#ifdef _WIN32
-    #define PEB_OFFSET 0x30
-    #define READ_MEMLOC __readfsdword 
-#endif
-
 #ifdef _WIN64
     #define PEB_OFFSET 0x60
     #define READ_MEMLOC __readgsqword 
+#else
+#define PEB_OFFSET 0x30
+#define READ_MEMLOC __readfsdword
 #endif
 
 #pragma once
@@ -30,6 +28,7 @@
 #define LDR_HASH_TABLE_ENTRIES 32
 
 HMODULE IsModulePresent(LPCWSTR lpwName);
+HMODULE IsModulePresentA(char* Name);
 BOOL LinkModuleToPEB(PDARKMODULE pdModule);
-FARPROC GetFunctionAddress(HMODULE hModule, LPCSTR  lpProcName);
+FARPROC GetFunctionAddress(HMODULE hModule, char*  ProcName);
 BOOL LocalLdrGetProcedureAddress(HMODULE hLibrary, PANSI_STRING ProcName, WORD Ordinal, PVOID* FunctionAddress);

--- a/DarkLoadLibrary/include/pebutils.h
+++ b/DarkLoadLibrary/include/pebutils.h
@@ -3,6 +3,11 @@
 #include "pebstructs.h"
 #include "darkloadlibrary.h"
 
+#define FILL_STRING(string, buffer) \
+    string.Length = (USHORT)strlen(buffer); \
+    string.MaximumLength = string.Length; \
+    string.Buffer = buffer
+
 #ifdef _WIN32
     #define PEB_OFFSET 0x30
     #define READ_MEMLOC __readfsdword 
@@ -26,3 +31,5 @@
 
 HMODULE IsModulePresent(LPCWSTR lpwName);
 BOOL LinkModuleToPEB(PDARKMODULE pdModule);
+FARPROC GetFunctionAddress(HMODULE hModule, LPCSTR  lpProcName);
+BOOL LocalLdrGetProcedureAddress(HMODULE hLibrary, PANSI_STRING ProcName, WORD Ordinal, PVOID* FunctionAddress);

--- a/DarkLoadLibrary/src/ldrutils.c
+++ b/DarkLoadLibrary/src/ldrutils.c
@@ -164,9 +164,9 @@ BOOL ResolveImports(
     PIMAGE_IMPORT_DESCRIPTOR pImportDesc;
     PIMAGE_DELAYLOAD_DESCRIPTOR pDelayDesc;
     PIMAGE_THUNK_DATA pFirstThunk, pOrigFirstThunk;
+    BOOL ok;
 
     STRING aString = { 0 };
-    LDRGETPROCADDRESS pLdrGetProcAddress = NULL;
 
     pNtHeaders = RVA(
         PIMAGE_NT_HEADERS,
@@ -175,16 +175,6 @@ BOOL ResolveImports(
     );
 
     pDataDir = &pNtHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
-
-    pLdrGetProcAddress = (LDRGETPROCADDRESS)GetProcAddress(
-        IsModulePresent(L"ntdll.dll"),
-        "LdrGetProcedureAddress"
-    );
-
-    if (!pLdrGetProcAddress)
-    {
-        return FALSE;
-    }
 
     // handle the import table
     if (pDataDir->Size)
@@ -232,12 +222,14 @@ BOOL ResolveImports(
             {
                 if (IMAGE_SNAP_BY_ORDINAL(pOrigFirstThunk->u1.Ordinal))
                 {
-                    pLdrGetProcAddress(
+                    ok = LocalLdrGetProcedureAddress(
                         hLibrary,
                         NULL,
                         (WORD)pOrigFirstThunk->u1.Ordinal,
                         (PVOID*)&(pFirstThunk->u1.Function)
                     );
+                    if (!ok)
+                        return FALSE;
                 }
                 else
                 {
@@ -251,13 +243,14 @@ BOOL ResolveImports(
                         aString,
                         pImportByName->Name
                     );
-
-                    pLdrGetProcAddress(
+                    ok = LocalLdrGetProcedureAddress(
                         hLibrary,
                         &aString,
                         0,
                         (PVOID*)&(pFirstThunk->u1.Function)
                     );
+                    if (!ok)
+                        return FALSE;
                 }
             }
         }
@@ -296,12 +289,14 @@ BOOL ResolveImports(
             {
                 if (IMAGE_SNAP_BY_ORDINAL(pOrigFirstThunk->u1.Ordinal))
                 {
-                    pLdrGetProcAddress(
+                    ok = LocalLdrGetProcedureAddress(
                         hLibrary,
                         NULL,
                         (WORD)pOrigFirstThunk->u1.Ordinal,
                         (PVOID*)&(pFirstThunk->u1.Function)
                     );
+                    if (!ok)
+                        return FALSE;
                 }
                 else
                 {
@@ -316,12 +311,14 @@ BOOL ResolveImports(
                         pImportByName->Name
                     );
 
-                    pLdrGetProcAddress(
+                    ok = LocalLdrGetProcedureAddress(
                         hLibrary,
                         &aString,
                         0,
                         (PVOID*)&(pFirstThunk->u1.Function)
                     );
+                    if (!ok)
+                        return FALSE;
                 }
             }
         }

--- a/DarkLoadLibrary/src/main.c
+++ b/DarkLoadLibrary/src/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <windows.h>
 
+#include "pebutils.h"
 #include "darkloadlibrary.h"
 
 typedef DWORD (WINAPI * _ThisIsAFunction) (LPCWSTR);
@@ -21,7 +22,7 @@ VOID main()
 		return;
 	}
 
-	_ThisIsAFunction ThisIsAFunction = GetProcAddress(
+	_ThisIsAFunction ThisIsAFunction = GetFunctionAddress(
 		DarkModule.ModuleBase,
 		"CallThisFunction"
 	);

--- a/DarkLoadLibrary/src/main.c
+++ b/DarkLoadLibrary/src/main.c
@@ -8,7 +8,7 @@ typedef DWORD (WINAPI * _ThisIsAFunction) (LPCWSTR);
 
 VOID main()
 {
-	DARKMODULE DarkModule = DarkLoadLibrary(
+	PDARKMODULE DarkModule = DarkLoadLibrary(
 		LOAD_LOCAL_FILE,
 		L"TestDLL.dll",
 		NULL,
@@ -16,16 +16,19 @@ VOID main()
 		NULL
 	);
 
-	if (!DarkModule.bSuccess)
+	if (!DarkModule->bSuccess)
 	{
-		printf("load failed: %S\n", DarkModule.ErrorMsg);
+		printf("load failed: %S\n", DarkModule->ErrorMsg);
+		HeapFree(GetProcessHeap(), 0, DarkModule->ErrorMsg);
+		HeapFree(GetProcessHeap(), 0, DarkModule);
 		return;
 	}
 
-	_ThisIsAFunction ThisIsAFunction = GetFunctionAddress(
-		DarkModule.ModuleBase,
+	_ThisIsAFunction ThisIsAFunction = (_ThisIsAFunction)GetFunctionAddress(
+		(HMODULE)DarkModule->ModuleBase,
 		"CallThisFunction"
 	);
+	HeapFree(GetProcessHeap(), 0, DarkModule);
 
 	if (!ThisIsAFunction)
 	{

--- a/DarkLoadLibrary/src/pebutils.c
+++ b/DarkLoadLibrary/src/pebutils.c
@@ -58,7 +58,7 @@ PLDR_DATA_TABLE_ENTRY2 FindLdrTableEntry(
 
 PRTL_RB_TREE FindModuleBaseAddressIndex()
 {
-	SIZE_T stEnd = NULL;
+	SIZE_T stEnd = 0;
 	PRTL_BALANCED_NODE pNode = NULL;
 	PRTL_RB_TREE pModBaseAddrIndex = NULL;
 
@@ -73,8 +73,8 @@ PRTL_RB_TREE FindModuleBaseAddressIndex()
 
 	if (!pNode->Red)
 	{
-		DWORD dwLen = NULL;
-		SIZE_T stBegin = NULL;
+		DWORD dwLen = 0;
+		SIZE_T stBegin = 0;
 
 		PIMAGE_NT_HEADERS pNtHeaders = RVA(
 			PIMAGE_NT_HEADERS, 
@@ -113,7 +113,7 @@ PRTL_RB_TREE FindModuleBaseAddressIndex()
 			}
 		}
 
-		if (stEnd == NULL)
+		if (stEnd == 0)
 		{
 			return NULL;
 		}
@@ -299,6 +299,15 @@ BOOL AddHashTableEntry(
 	return TRUE;
 }
 
+HMODULE IsModulePresentA(
+	char* Name
+)
+{
+	wchar_t wtext[500];
+	mbstowcs(wtext, Name, strlen(Name) + 1);
+	return IsModulePresent(wtext);
+}
+
 HMODULE IsModulePresent(
 	LPCWSTR lpwName
 )
@@ -327,7 +336,7 @@ HMODULE IsModulePresent(
 		)
 		{
 			// already loaded, so return the base address
-			return (ULONG_PTR)pLdrTbl->DllBase;
+			return (HMODULE)pLdrTbl->DllBase;
 		}
 
 		pModList = pModList->Flink;
@@ -338,13 +347,13 @@ HMODULE IsModulePresent(
 
 FARPROC GetFunctionAddress(
 	HMODULE hModule,
-	LPCSTR  lpProcName
+	char*  ProcName
 )
 {
 	STRING aString = { 0 };
 	FILL_STRING(
 		aString,
-		lpProcName
+		ProcName
 	);
 
 	PVOID FunctionAddress = NULL;
@@ -366,19 +375,78 @@ BOOL LocalLdrGetProcedureAddress(
 	PVOID* FunctionAddress
 )
 {
+	if (ProcName == NULL && Ordinal == 0)
+	{
+		printf("LocalLdrGetProcedureAddress: provide either a Function name or Ordinal\n");
+		return FALSE;
+	}
+
+	if (ProcName != NULL && Ordinal != 0)
+	{
+		printf("LocalLdrGetProcedureAddress: provide Function name or Ordinal, not both\n");
+		return FALSE;
+	}
+
+	BOOL ok = FALSE;
+	if (hLibrary != NULL)
+	{
+		ok = _LocalLdrGetProcedureAddress(
+			hLibrary,
+			ProcName,
+			Ordinal,
+			FunctionAddress
+		);
+		if (ok)
+			return TRUE;
+	}
+
+	// some deprecated DLLs have their functions implemented in KERNEL32 and KERNELBASE
+	PVOID kernel32_addr = IsModulePresent(L"KERNEL32.dll");
+	if (kernel32_addr != hLibrary)
+	{
+		ok = _LocalLdrGetProcedureAddress(
+			kernel32_addr,
+			ProcName,
+			Ordinal,
+			FunctionAddress
+		);
+	}
+	if (ok)
+		return TRUE;
+
+	PVOID kernelbase_addr = IsModulePresent(L"KERNELBASE.dll");
+	if (kernelbase_addr != hLibrary)
+	{
+		ok = _LocalLdrGetProcedureAddress(
+			kernelbase_addr,
+			ProcName,
+			Ordinal,
+			FunctionAddress
+		);
+	}
+	if (ok)
+		return TRUE;
+
+	if (ProcName != NULL)
+		printf("LocalLdrGetProcedureAddress: unable to resolve address of function: %s\n", ProcName->Buffer);
+	else
+		printf("LocalLdrGetProcedureAddress: unable to resolve address of function ordinal: %d\n", Ordinal);
+	return FALSE;
+}
+
+BOOL _LocalLdrGetProcedureAddress(
+	HMODULE hLibrary,
+	PANSI_STRING ProcName,
+	WORD Ordinal,
+	PVOID* FunctionAddress
+)
+{
 	PIMAGE_NT_HEADERS pNtHeaders;
 	PIMAGE_DATA_DIRECTORY pDataDir;
 	PIMAGE_EXPORT_DIRECTORY pExpDir;
 	PIMAGE_SECTION_HEADER pSecHeader;
 
 	if (hLibrary == NULL)
-		return FALSE;
-
-	if (ProcName == NULL && Ordinal == 0)
-		return FALSE;
-
-	// choose only one
-	if (ProcName != NULL && Ordinal != 0)
 		return FALSE;
 
 	pNtHeaders = RVA(
@@ -388,11 +456,15 @@ BOOL LocalLdrGetProcedureAddress(
 	);
 
 	if (pNtHeaders->Signature != IMAGE_NT_SIGNATURE)
+	{
+		printf("LocalLdrGetProcedureAddress: invalid IMAGE_NT_SIGNATURE\n");
 		return FALSE;
+	}
 
 	// find the address range for the .text section
-	PVOID startTextSection = NULL;
-	PVOID endTextSection = NULL;
+	PVOID startValidSection = NULL;
+	PVOID endValidSection = NULL;
+
 	for (int i = 0; i < pNtHeaders->FileHeader.NumberOfSections; i++)
 	{
 		pSecHeader = RVA(
@@ -402,20 +474,20 @@ BOOL LocalLdrGetProcedureAddress(
 		);
 		if (strncmp(".text", pSecHeader->Name, 6) == 0)
 		{
-			startTextSection = RVA(
+			startValidSection = RVA(
 				PVOID,
 				hLibrary,
 				pSecHeader->VirtualAddress
 			);
-			endTextSection = RVA(
+			endValidSection = RVA(
 				PVOID,
-				startTextSection,
+				startValidSection,
 				pSecHeader->SizeOfRawData
 			);
 			break;
 		}
 	}
-	if (startTextSection == NULL || endTextSection == NULL)
+	if (startValidSection == NULL || endValidSection == NULL)
 		return FALSE;
 
 	pDataDir = &pNtHeaders->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
@@ -488,7 +560,7 @@ BOOL LocalLdrGetProcedureAddress(
 					*pFunctionRVA
 				);
 
-				if (FunctionPtr < startTextSection || FunctionPtr >  endTextSection)
+				if (startValidSection > FunctionPtr || FunctionPtr > endValidSection)
 				{
 					// this is not a pointer to a function, but a reference to another library with the real address
 					size_t full_length = strlen((char*)FunctionPtr);
@@ -501,43 +573,48 @@ BOOL LocalLdrGetProcedureAddress(
 							break;
 						}
 					}
-					if (lib_length == 0)
-						return FALSE;
-					size_t func_length = full_length - lib_length - 1;
-					char* libname = HeapAlloc(
-						GetProcessHeap(),
-						HEAP_ZERO_MEMORY,
-						2 * (lib_length + 5)
-					);
-					if (!libname)
-						return FALSE;
-
-					for (int j = 0; j < lib_length; j++)
+					if (lib_length != 0)
 					{
-						libname[j * 2 + 0] = ((char*)FunctionPtr)[j];
-						libname[j * 2 + 1] = 0;
+
+						size_t func_length = full_length - lib_length - 1;
+						char* libname = HeapAlloc(
+							GetProcessHeap(),
+							HEAP_ZERO_MEMORY,
+							lib_length + 5
+						);
+						if (!libname)
+							return FALSE;
+						strncpy(libname, (char*)FunctionPtr, lib_length);
+						strncpy(libname + lib_length, ".dll", 5);
+						char* funcname = (char*)FunctionPtr + lib_length + 1;
+						STRING funcname_s = { 0 };
+						FILL_STRING(
+							funcname_s,
+							funcname
+						);
+						PVOID lib_addr = IsModulePresentA(libname);
+						if (lib_addr == NULL || lib_addr == hLibrary)
+						{
+							HeapFree(GetProcessHeap(), 0, libname); libname = NULL;
+							return FALSE;
+						}
+
+						// call ourselves recursively
+						BOOL ok = FALSE;
+						ok = LocalLdrGetProcedureAddress(
+							lib_addr,
+							&funcname_s,
+							0,
+							&FunctionPtr
+						);
+						if (!ok)
+						{
+							printf("LocalLdrGetProcedureAddress: failed to resolve address of: %s!%s\n", libname, funcname);
+							HeapFree(GetProcessHeap(), 0, libname); libname = NULL;
+							return FALSE;
+						}
+						HeapFree(GetProcessHeap(), 0, libname); libname = NULL;
 					}
-					libname[lib_length * 2 + 0] = '.'; libname[lib_length * 2 + 1] = 0;
-					libname[lib_length * 2 + 2] = 'd'; libname[lib_length * 2 + 3] = 0;
-					libname[lib_length * 2 + 4] = 'l'; libname[lib_length * 2 + 5] = 0;
-					libname[lib_length * 2 + 6] = 'l'; libname[lib_length * 2 + 7] = 0;
-					libname[lib_length * 2 + 8] = 0; libname[lib_length * 2 + 9] = 0;
-					char* funcname = (char*)FunctionPtr + lib_length + 1;
-					STRING funcname_s = { 0 };
-					FILL_STRING(
-						funcname_s,
-						funcname
-					);
-					// call ourselves recursively
-					BOOL result = LocalLdrGetProcedureAddress(
-						IsModulePresent((LPCWSTR)libname),
-						&funcname_s,
-						0,
-						&FunctionPtr
-					);
-					HeapFree(GetProcessHeap(), 0, libname); libname = NULL;
-					if (!result)
-						return FALSE;
 				}
 				*FunctionAddress = FunctionPtr;
 				return TRUE;
@@ -601,7 +678,7 @@ BOOL LinkModuleToPEB(
 	// correctly add the base address to the entry
 	AddBaseAddressEntry(
 		pLdrEntry,
-		pdModule->ModuleBase
+		(PVOID)pdModule->ModuleBase
 	);
 
 	// an the rest


### PR DESCRIPTION
Hello again 😄 

With this PR, we find the export address of all DLL functions ourselves, so we no longer rely on `GetProcAddress` and `LdrGetProcedureAddress`. The idea is to stay away from Kernel32 and NTDLL as much as possible. Resolving several functions might lead to detection

I have tried to resolve all exports of Kernel32, NTDLL, User32. vcruntime40 and stdlib and it worked very well, so I am confident the implementation is solid.

One interesting thing I found while developing this:
For some weird reason, Kernel32 (and a few others) exports some functions that aren't really defined in Kernel32, but in other libraries (maybe everybody knew this but me?)
When you try to resolve those functions, you get a pointer to a string that describes where that function is truly defined.
For example, _AcquireSRWLockExclusive_ is a function exported by Kernel32, that resolves to an address that has this string: `NTDLL.RtlAcquireSRWLockExclusive`,  meaning the function is defined in ntdll as _RtlAcquireSRWLockExclusive_.
So that is why the function is recursive, it needs to handle those cases. (luckily your test DLL loads one of these "fake" exports, so I was able to find this behavior)

Anyway, hope you find it useful

Edit:
I have also found that in some weird cases, libraries such as Kernel32 does this thing where a function "points" to another library and function name, but the library is like deprecated and the function is in truth implemented in Kernel32.
That is why if the resolve fails, it tries with Kernel32 and KernelBase. You can try to resolve all exports of the DLL you like and compare the result with what `LdrGetProcedureAddress` says it is and confirm that it works for all cases.
Let me know if this is unclear and you want to clarify something.